### PR TITLE
Updated website links (Github -> website)

### DIFF
--- a/website/docs/API Gateway/Apache-APISIX.md
+++ b/website/docs/API Gateway/Apache-APISIX.md
@@ -11,7 +11,7 @@
 
 **Github**: [apache/apisix](https://github.com/apache/apisix)
 
-**Website**: [github.com/apache/apisix](https://github.com/apache/apisix)
+**Website**: [apisix.apache.org](https://apisix.apache.org/)
 
 **Description**:
 Cloud Native API Gateway under the Apache Software Foundation

--- a/website/docs/API Platform/Fusio.md
+++ b/website/docs/API Platform/Fusio.md
@@ -11,7 +11,7 @@
 
 **Github**: [apioo/fusio](https://github.com/apioo/fusio)
 
-**Website**: [github.com/apioo/fusio](https://github.com/apioo/fusio)
+**Website**: [fusio-project.org](https://www.fusio-project.org/)
 
 **Description**:
 API management platform


### PR DESCRIPTION
Both GitHub & website link sends to GitHub repo. Updated website link for redirecting to project home page instead. Applied to:   
- apache-apisix
- apioo-fusio