### PR TITLE
Add GeoInfomatic to Useful Links (bootstrapped accessibility analyzer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Any questions or suggestions? Feel free to DM project maintainer [@garrrikkotua]
 
 ## Startup List
 
+
+- [GeoInfomatic](https://geoinfomatic.pythonanywhere.com) — Korean isochrone-based neighborhood accessibility analyzer. Bootstrapped freemium alternative to commercial Walk Score / location intelligence tools.
 All startups in the list are sorted by categories and sorted in alphabetical order. If you click on the stars badge you will get to the product's repo. 
 **Have a good search!**
 


### PR DESCRIPTION
Adds **GeoInfomatic** to the Useful Links section.

- URL: https://geoinfomatic.pythonanywhere.com
- Acts as a bootstrapped alternative to paid Walk Score / location intelligence APIs for the Korean market
- 100% open data (OSM + Korean public transit)
- Solo-built, freemium model ($7/mo Pro)

Not a traditional startup — happy to revise placement.
